### PR TITLE
ci: bump workflow action versions to latest

### DIFF
--- a/.github/workflows/release-supply-chain.yml
+++ b/.github/workflows/release-supply-chain.yml
@@ -25,7 +25,13 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-auditable
-      - uses: sigstore/cosign-installer@v3
+      # cosign v3 changed `sign-blob` keyless output to bundle-only format, which
+      # would drop the .sig/.pem artifacts verified via `cosign verify-blob
+      # --signature/--certificate` in README. Pin 2.x until the verification flow
+      # migrates to bundles.
+      - uses: sigstore/cosign-installer@v4
+        with:
+          cosign-release: "v2.6.5"
 
       - name: Package publishable crates
         run: cargo package --workspace --locked --no-verify --allow-dirty
@@ -64,12 +70,12 @@ jobs:
           done
 
       - name: Attest packaged crates
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: "dist/*.crate"
 
       - name: Publish release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
## Summary

Updated the GitHub Actions versions under `.github/workflows` to the latest releases. Only `release-supply-chain.yml` had outdated actions; all other workflows were already current.

| Action | Before | After | Notes |
|---|---|---|---|
| `sigstore/cosign-installer` | v3 | v4 | Pinned `cosign-release: v2.6.5` — cosign v3 changed `sign-blob` keyless output to bundle-only format, which would drop the `.sig`/`.pem` artifacts verified via `cosign verify-blob --signature/--certificate` in the README. Pin can be removed once the verification flow migrates to bundles. |
| `actions/attest-build-provenance` | v2 | v4 | v4 is a wrapper over `actions/attest`; `subject-path` input unchanged. |
| `softprops/action-gh-release` | v2 | v3 | Node 24 runtime; inputs unchanged, supported on GitHub-hosted runners. |

Already at latest (no change): `actions/checkout@v7` (v7.0.1), `actions/cache@v6` (v6.1.0), `rustsec/audit-check@v2` (v2.0.0), `taiki-e/install-action@v2` (v2.87.8), `github/codeql-action@v4.37.9`, `dtolnay/rust-toolchain` (branch ref).

## Test plan

- [x] YAML syntax validated
- [ ] Next tag push exercises the release pipeline (signing, attestation, release upload)